### PR TITLE
Finalizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventuals"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Zac Burns <That3Percent@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-Eventuals are eventually consistent values that update over time.
+Eventuals give you the most up-to-date snapshots of some value. They are like Futures that update over time, continually resolving to an eventually consistent state. You can chain eventuals together, inspect their present value, and subscribe for updates. The eventual paradigm is the culmination of many hard lessons in asynchronous programming.
+
+
+Consider this code using an imaginary set_interval inspired by JavaScript:
+```rust
+set_interval(|| async { let update = fetch().await; set_ui_data(update); }, 2000)
+```
+
+The above is a typical pattern used to update a UI from external data over time. There are a couple of problems with this code. First, the fetch operations may overlap. This overlap can result in stale data being shown in the UI after new data! Furthermore, there is no clear way to cancel - either from the reading or the writing perspective.
+
+
+Eventuals solve these and other common issues!
+
+```rust
+
+let cancel_on_drop = timer(2000).map(|_| fetch).pipe(set_ui_update);
+
+```
+
+Here, `set_ui_update` is guaranteed to progress only forward in time. Different pipeline stages may execute concurrently, and some updates may be skipped if newer values are available. Still, the eventual state will always be consistent with the final writes to data.
+
+
+# Subscriptions
+
+Subscriptions are views of the latest update of an eventual from the reader's perspective. A subscription will only observe an update if the value has changed since the last observation and may skip updates between the previous and current observations. Taken together, this ensures that any reader performs the least amount of work necessary to be eventually consistent with the state of the writer.
+
+
+You can get a subscription by calling `eventual.subscribe()` and `subscription.next().await` any time you are ready to process an update. If there has been an update since the previously processed update the Future is ready immediately, otherwise it will resolve as soon as an update is available.
+
+
+# Snapshots
+There are two ways to get the current value of an eventual without a subscription. These are `eventual.value_immediate()` and `eventual.value`, depending on whether you want to wait for the first update.
+
+# Unit tests
+
+One useful application of eventuals is to make components testable without mocks. Instead of making a mock server (which requires traits) you can supply your component with an eventual and feed the component data. It's not dependency injection. It's data injection.
+
+
+# FAQ
+
+    What is the difference between an eventual and a Stream?
+
+ A Stream is a collection of distinct, ordered values that are made available asynchronously. An eventual, however, is an asynchronous view of a single value changing over time.
+
+
+    The API seems sparse. I see map and join, but where are filter, reduce, and select?
+
+It is natural to want to apply the full range of functional techniques to eventuals, but this is an anti-pattern. The goal of eventuals is to make the final value of any view of any data pipeline deterministically consistent with the latest write. The path to producing a result may not be deterministic, but the final value is consistent if each building block is also consistent. Not every functional block passes this test. To demonstrate, we can compare the behavior of map and an imaginary filter combinator on the same sequence of writes.
+
+
+Consider `eventual.map(|n| async move { n * 2 })` and `eventual.filter(|n| async move { n % 2 == 0 })` both consuming the series writes `[0, 1, 2, 3, 4, 5]` over time. `map`, in this case, will always eventually resolve to the value `10`. It may also produce some subset of intermediate values along the way (like `[0, 4, 8, 10]` or `[2, 10]`). Still, it will always progress forward in time and always resolves to a deterministic value consistent with the final write. However, the final value that `filter` produces would be a function of which intermediate values were observed. If filter observes the subset of writes  `[0, 2, 5]`, it will resolve to `2`, but if it observes the subset of writes `[1, 4, 5]`, it will resolve to `5`. This bug is exactly the kind eventuals are trying to avoid.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,2 @@
-// TODO: Closed<T>(Option<T>) to pass final update if any
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Closed;

--- a/src/eventual/change.rs
+++ b/src/eventual/change.rs
@@ -58,7 +58,7 @@ where
         let value = mem::replace(lock.deref_mut(), ChangeVal::None);
 
         match value {
-            // If there is a new value and it is different than our prevously
+            // If there is a new value and it is different than our previously
             // observed value return it. Otherwise fall back to waking later.
             ChangeVal::Value(value) => {
                 let value = Some(Ok(value));
@@ -130,7 +130,7 @@ where
                 ChangeVal::Finalized(finalized) => {
                     // Verify that it's not copying the final value over again
                     // because in racey situations it may have been copied once
-                    // then had the value consumed. It would't be the end of the
+                    // then had the value consumed. It wouldn't be the end of the
                     // world to reset the finalized state, but would result in
                     // some unnecessary work.
                     if !matches!(prev, ChangeVal::Finalized(_)) {

--- a/src/eventual/eventual.rs
+++ b/src/eventual/eventual.rs
@@ -1,4 +1,6 @@
-use super::change::ChangeReader;
+use std::ops::DerefMut;
+
+use super::change::{ChangeReader, ChangeVal};
 use super::shared_state::SharedState;
 use super::*;
 use crate::IntoReader;
@@ -6,6 +8,9 @@ use futures::channel::oneshot;
 use futures::never::Never;
 use tokio::select;
 
+/// The entry point for getting the latest snapshots of values
+/// written by an EventualWriter. It supports multiple styles
+/// of observation.
 pub struct Eventual<T> {
     state: Arc<SharedState<T>>,
 }
@@ -14,12 +19,24 @@ impl<T> Eventual<T>
 where
     T: Value,
 {
+    /// Create a reader/writer pair.
     pub fn new() -> (EventualWriter<T>, Self) {
         let (sender, receiver) = oneshot::channel();
         let state = Arc::new(SharedState::new(sender));
         (EventualWriter::new(&state, receiver), Eventual { state })
     }
 
+    /// Create an eventual having a final value. This is useful for creating
+    /// "mock" eventuals to pass into consumers.
+    pub fn from_value(value: T) -> Self {
+        let (mut writer, eventual) = Eventual::new();
+        writer.write(value);
+        eventual
+    }
+
+    /// A helper for spawning a task which writes to an eventual.
+    /// These are used extensively within the library for eventuals
+    /// which update continuously over time.
     pub fn spawn<F, Fut>(f: F) -> Self
     where
         F: 'static + Send + FnOnce(EventualWriter<T>) -> Fut,
@@ -35,14 +52,39 @@ where
         eventual
     }
 
+    /// Subscribe to present and future snapshots of the value in this Eventual.
+    /// Generally speaking the observations of snapshots take into account the
+    /// state of the reader such that:
+    ///   * The same observation is not made redundantly (same value twice in a
+    ///     row)
+    ///   * The observations always move forward in time
+    ///   * The final observation will always be eventually consistent with the
+    ///     final write.
     pub fn subscribe(&self) -> EventualReader<T> {
         EventualReader::new(self.state.clone())
     }
 
+    /// Get a future that resolves with a snapshot of the present value of the
+    /// Eventual, if any, or a future snapshot if none is available. Which
+    /// snapshot is returned depends on when the Future is polled (as opposed
+    /// to when the Future is created)
     pub fn value(&self) -> ValueFuture<T> {
         let change = self.state.clone().subscribe();
         ValueFuture {
             change: Some(change),
+        }
+    }
+
+    /// Get a snapshot of the current value of this Eventual, if any,
+    /// without waiting.
+    pub fn value_immediate(&self) -> Option<T> {
+        match self.state.last_write.lock().unwrap().deref_mut() {
+            ChangeVal::None => None,
+            ChangeVal::Value(t) => Some(t.clone()),
+            ChangeVal::Finalized(t) => t.clone(),
+            ChangeVal::Waker(_) => {
+                unreachable!();
+            }
         }
     }
 
@@ -62,14 +104,8 @@ where
 {
     type Output = Result<T, Closed>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut swap = None;
-        let prev = None;
-        self.change
-            .as_mut()
-            .unwrap()
-            .change
-            .swap_or_wake(&mut swap, &prev, cx);
-        match swap {
+        let update = self.change.as_mut().unwrap().change.poll(&None, cx);
+        match update {
             None => Poll::Pending,
             Some(value) => {
                 self.change = None;

--- a/src/eventual/eventual_ext.rs
+++ b/src/eventual/eventual_ext.rs
@@ -2,6 +2,7 @@ use crate::*;
 use futures::Future;
 use std::time::Duration;
 
+/// Fluent style API extensions for any Eventual reader.
 pub trait EventualExt: Sized + IntoReader {
     #[inline]
     fn map<F, O, Fut>(self, f: F) -> Eventual<O>

--- a/src/eventual/reader.rs
+++ b/src/eventual/reader.rs
@@ -38,12 +38,8 @@ where
     // the future that would produce values. But... that may be very complex. A
     // refactor may be necessary.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut swap = None;
-        self.eventual
-            .change
-            .change
-            .swap_or_wake(&mut swap, &self.eventual.prev, cx);
-        match swap {
+        let update = self.eventual.change.change.poll(&self.eventual.prev, cx);
+        match update {
             None => Poll::Pending,
             Some(value) => {
                 self.eventual.prev = Some(value.clone());

--- a/src/eventual/reader.rs
+++ b/src/eventual/reader.rs
@@ -34,7 +34,7 @@ where
 {
     type Output = Result<T, Closed>;
     // TODO: This is currently checking for a pushed value, but that will require
-    // eg: map() to run in separate tasks. It might be desireble to have this poll
+    // eg: map() to run in separate tasks. It might be desirable to have this poll
     // the future that would produce values. But... that may be very complex. A
     // refactor may be necessary.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/eventual/shared_state.rs
+++ b/src/eventual/shared_state.rs
@@ -1,4 +1,3 @@
-use crate::error::Closed;
 use futures::channel::oneshot::Sender;
 use std::{
     collections::HashSet,
@@ -7,7 +6,7 @@ use std::{
 };
 
 use super::{
-    change::{Change, ChangeReader},
+    change::{Change, ChangeReader, ChangeVal},
     *,
 };
 
@@ -19,7 +18,7 @@ pub struct SharedState<T> {
     // These taken together advocate for a snapshot-at-time style of concurrency
     // which makes snapshotting very cheap but updates expensive.
     pub subscribers: Mutex<Arc<HashSet<Change<T>>>>,
-    pub last_write: Mutex<Option<Result<T, Closed>>>,
+    pub last_write: Mutex<ChangeVal<T>>,
     writer_notify: Option<Sender<()>>,
 }
 
@@ -41,7 +40,7 @@ where
     pub fn new(writer_notify: Sender<()>) -> Self {
         Self {
             subscribers: Mutex::new(Arc::new(HashSet::new())),
-            last_write: Mutex::new(None),
+            last_write: Mutex::new(ChangeVal::None),
             writer_notify: Some(writer_notify),
         }
     }

--- a/tests/eventual.rs
+++ b/tests/eventual.rs
@@ -20,10 +20,10 @@ async fn can_observe_value_written_after_subscribe() {
 
 #[test]
 async fn can_observe_value_written_before_subscribe() {
-    let (mut writer, eventual) = Eventual::new();
-    writer.write(5);
+    let eventual = Eventual::from_value(5);
     let mut read_0 = eventual.subscribe();
     assert_eq!(read_0.next().await, Ok(5));
+    assert_eq!(read_0.next().await, Err(Closed));
 }
 
 #[test]


### PR DESCRIPTION
The main update here is that subscriptions can always observe the final value even if the eventual is closed. This makes a lot more sense than what was happening before (at the expense of some terribly messy internal code).

Also added docs, some minor APIs, and a bump to 0.3.0. I think this should be the last update before putting this to use.