### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/eventual/change.rs
+++ b/src/eventual/change.rs
@@ -60,14 +60,14 @@ impl<T> Busy<T> {
     }
 
     fn unbusy(mut self) -> T {
-        unsafe {
-            let inner = ptr::read(&mut self.0);
+        
+            let inner = unsafe {ptr::read(&mut self.0)};
             mem::forget(self);
             #[cfg(feature = "trace")]
             busy::clear_busy();
 
             inner
-        }
+        
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. However, I found that only 1 function is real unsafe operation (see the list below).

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.
**Real unsafe operation list:**
1. the ptr::read() function(unsafe function)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
